### PR TITLE
fix(go-to-gno): add rpc flag to gnodev

### DIFF
--- a/presentations/2024-03-23--seoul-go-to-gno--leon/README.md
+++ b/presentations/2024-03-23--seoul-go-to-gno--leon/README.md
@@ -94,7 +94,7 @@ and expose an RPC endpoint for the UI to connect to it. Start `gnodev`, giving
 it the paths to the Memeland package and realm folders:
 
 ```
-gnodev ./api/p/memeland ./api/r/memeland
+gnodev --node-rpc-listener 127.0.0.1:26657 ./api/p/memeland ./api/r/memeland
 ```
 
 Then, in the `ui/` folder:


### PR DESCRIPTION
This PR adds a necessary flag to the README of the Go to Gno Korea tutorial. This flag is needed because currently Adena does not allow you to change the default local network RPC endpoint, so you need to match it with the `gnodev` RPC endpoint.